### PR TITLE
Fix conservative mode

### DIFF
--- a/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
+++ b/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
@@ -58,6 +58,9 @@ RUN cd /opt/build/ &&\
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+# Check that no AVX2/AVX512 instructions are emitted
+RUN if [[ $( objdump -d /usr/local/lib/liblapack.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+
 # Restore default behavior for verificarlo's CC
 ENV CC "verificarlo-c"
 ENV VFC_BACKENDS_SILENT_LOAD="True"

--- a/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
+++ b/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
@@ -20,9 +20,9 @@ COPY docker/resources/verificarlo.patch /tmp/verificarlo.patch
 RUN patch $(which verificarlo) /tmp/verificarlo.patch
 
 # Setting compilers and linkers to use verificarlo
-ENV CC "verificarlo-c"
-ENV CXX "verificarlo-c++"
-ENV FC "verificarlo-f"
+ENV CC "verificarlo-c --conservative"
+ENV CXX "verificarlo-c++ --conservative"
+ENV FC "verificarlo-f --conservative"
 
 # Load backend IEEE
 RUN mkdir -p /opt/ && touch /opt/vfc-backends.txt

--- a/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
+++ b/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
@@ -1,9 +1,6 @@
 ARG VERIFICARLO_VERSION=v0.5.0
 FROM verificarlo/verificarlo:${VERIFICARLO_VERSION}
 
-RUN cat /proc/cpuinfo | grep flags | uniq
-RUN  cat /proc/cpuinfo | grep "model name"  | uniq
-
 # Setup build dependencies
 RUN apt-get update -qqq &&\
     apt-get install -y --no-install-recommends -qqq \
@@ -59,7 +56,7 @@ RUN cd /opt/build/ &&\
 RUN rm -rf /opt/build/*
 
 # Check that no AVX2/AVX512 instructions are emitted
-RUN if [[ $( objdump -d /usr/local/lib/liblapack.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+RUN if [ $( objdump -d /usr/local/lib/liblapack.so | grep "%ymm\|%zmm" | wc -l ) != 0 ] ; then exit 1 ; fi
 
 # Restore default behavior for verificarlo's CC
 ENV CC "verificarlo-c"

--- a/docker/base/Dockerfile.ubuntu20.04-1-python
+++ b/docker/base/Dockerfile.ubuntu20.04-1-python
@@ -1,15 +1,6 @@
 ARG VERIFICARLO_VERSION=v0.5.0
 FROM verificarlo/fuzzy:${VERIFICARLO_VERSION}-lapack
 
-RUN cat /proc/cpuinfo | grep flags | uniq
-RUN  cat /proc/cpuinfo | grep "model name"  | uniq
-
-
-# Unset LD_PRELOAD because it will open VFC_BACKENDS_FROM_FILE
-# and causes bug
-RUN LD_PRELOAD_OLD=${LD_PRELOAD}
-ENV LD_PRELOAD=""
-
 # Setting compilers and linkers to use verificarlo
 ENV CC "verificarlo-c --conservative"
 ENV CXX "verificarlo-c++ --conservative"
@@ -26,7 +17,7 @@ RUN cd /opt/build/ && \
     wget https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz && \
     tar xvf Python-3.8.5.tgz && \
     cd Python-3.8.5 && \
-    CFLAGS="--exclude-file=/tmp/python-vfc-exclude.txt --conservative" ./configure --enable-optimizations --with-ensurepip=install &&\
+    CFLAGS="--exclude-file=/tmp/python-vfc-exclude.txt --conservative -Wunused-command-line-argument" ./configure --enable-optimizations --with-ensurepip=install &&\
     make -j &&\
     make install &&\ 
     wget https://bootstrap.pypa.io/get-pip.py &&\
@@ -36,14 +27,12 @@ RUN cd /opt/build/ && \
 RUN rm -rf /opt/build/*
 
 # Check that no AVX2/AVX512 instructions are emitted
-RUN if [[ $( objdump -d $(which python3) | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+RUN if [ $( objdump -d $(which python3) | grep "%ymm\|%zmm" | wc -l ) != 0 ] ; then exit 1 ; fi
 
 # Restore default behavior for verificarlo's CC
 ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
-
-ENV LD_PRELOAD=${LD_PRELOAD_OLD}
 
 # Set entrypoint
 ENTRYPOINT [ "/bin/bash"]

--- a/docker/base/Dockerfile.ubuntu20.04-1-python
+++ b/docker/base/Dockerfile.ubuntu20.04-1-python
@@ -10,6 +10,11 @@ RUN  cat /proc/cpuinfo | grep "model name"  | uniq
 RUN LD_PRELOAD_OLD=${LD_PRELOAD}
 ENV LD_PRELOAD=""
 
+# Setting compilers and linkers to use verificarlo
+ENV CC "verificarlo-c --conservative"
+ENV CXX "verificarlo-c++ --conservative"
+ENV FC "verificarlo-f --conservative"
+
 # Use IEEE mode for compiling with verificarlo
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
 
@@ -30,6 +35,11 @@ RUN cd /opt/build/ && \
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+# Check that no AVX2/AVX512 instructions are emitted
+RUN if [[ $( objdump -d $(which python3) | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+
+# Restore default behavior for verificarlo's CC
+ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
 

--- a/docker/base/Dockerfile.ubuntu20.04-2-numpy
+++ b/docker/base/Dockerfile.ubuntu20.04-2-numpy
@@ -1,22 +1,8 @@
 ARG VERIFICARLO_VERSION=v0.5.0
 FROM verificarlo/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5
 
-RUN cat /proc/cpuinfo | grep flags | uniq
-RUN  cat /proc/cpuinfo | grep "model name"  | uniq
-
-
-# Unset LD_PRELOAD because it will open VFC_BACKENDS_FROM_FILE
-# and causes bug
-RUN LD_PRELOAD_OLD=${LD_PRELOAD}
-ENV LD_PRELOAD=""
-
 # Use IEEE mode for compiling with verificarlo
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
-
-# Setting compilers and linkers to use verificarlo
-ENV CC "verificarlo-c --conservative"
-ENV CXX "verificarlo-c++ --conservative"
-ENV FC "verificarlo-f --conservative"
 
 # Copy verificarlo's exclusion file for Python 3
 COPY docker/resources/numpy-verificarlo.patch /tmp/numpy-verificarlo.patch
@@ -25,6 +11,11 @@ COPY docker/resources/numpy-vfc-exclude.txt /tmp/numpy-vfc-exclude.txt
 RUN  git config --global user.email "fake@mail.com" &&\
     git config --global user.name "Anonymous Patcher" 
 
+ENV CFLAGS "--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative " 
+ENV FFLAGS "--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative" 
+ENV OPT "--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative" 
+ENV FOPT "--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative"
+
 # Build numpy from sources and link with the local BLAS and LAPACK
 RUN python3 -m pip install cython
 RUN cd /opt/build &&\
@@ -32,8 +23,6 @@ RUN cd /opt/build &&\
     cd /opt/build/numpy &&\
     git checkout v1.19.1 &&\
     git am /tmp/numpy-verificarlo.patch &&\
-    OPT="--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative" \
-    FOPT="--exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument --conservative" \
     NPY_BLAS_ORDER=BLAS NPY_LAPACK_ORDER=LAPACK \
     python3 setup.py config --compiler=verificarlo --fcompiler=verificarlof build_clib \
     --compiler=verificarlo --fcompiler=verificarlof build_ext \
@@ -46,14 +35,7 @@ RUN python3 -c "import numpy as np; x = np.array(range(4),dtype=np.float64); z=[
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
-# Check that no AVX2/AVX512 instructions are emitted
-RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/numpy-1.19.1-py3.8-linux-x86_64.egg/numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
-
-# Restore default behavior for verificarlo's CC
-ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
-
-ENV LD_PRELOAD=${LD_PRELOAD_OLD}
 
 ENTRYPOINT [ "/bin/bash"]

--- a/docker/base/Dockerfile.ubuntu20.04-2-numpy
+++ b/docker/base/Dockerfile.ubuntu20.04-2-numpy
@@ -13,6 +13,11 @@ ENV LD_PRELOAD=""
 # Use IEEE mode for compiling with verificarlo
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
 
+# Setting compilers and linkers to use verificarlo
+ENV CC "verificarlo-c --conservative"
+ENV CXX "verificarlo-c++ --conservative"
+ENV FC "verificarlo-f --conservative"
+
 # Copy verificarlo's exclusion file for Python 3
 COPY docker/resources/numpy-verificarlo.patch /tmp/numpy-verificarlo.patch
 COPY docker/resources/numpy-vfc-exclude.txt /tmp/numpy-vfc-exclude.txt
@@ -41,6 +46,11 @@ RUN python3 -c "import numpy as np; x = np.array(range(4),dtype=np.float64); z=[
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+# Check that no AVX2/AVX512 instructions are emitted
+RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/numpy-1.19.1-py3.8-linux-x86_64.egg/numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+
+# Restore default behavior for verificarlo's CC
+ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
 

--- a/docker/base/Dockerfile.ubuntu20.04-3-scipy
+++ b/docker/base/Dockerfile.ubuntu20.04-3-scipy
@@ -1,14 +1,5 @@
 ARG VERIFICARLO_VERSION=v0.5.0
-FROM verificarlo/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5-numpy
-
-RUN cat /proc/cpuinfo | grep flags | uniq
-RUN  cat /proc/cpuinfo | grep "model name"  | uniq
-
-
-# Unset LD_PRELOAD because it will open VFC_BACKENDS_FROM_FILE
-# and causes bug
-RUN LD_PRELOAD_OLD=${LD_PRELOAD}
-ENV LD_PRELOAD=""
+FROM yohanchatelain/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5-numpy
 
 # Load backend IEEE
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
@@ -32,6 +23,7 @@ RUN cd /opt/build/ &&\
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+# Check that no AVX2/AVX512 instructions are emitted
 RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/scipy-1.5.4-py3.8-linux-x86_64.egg/scipy/linalg/cython_blas.cpython-38-x86_64-linux-gnu.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
 
 
@@ -39,7 +31,5 @@ RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/scipy-1.5.4-py3.8
 ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
-
-ENV LD_PRELOAD=${LD_PRELOAD_OLD}
 
 ENTRYPOINT [ "/bin/bash"]

--- a/docker/base/Dockerfile.ubuntu20.04-3-scipy
+++ b/docker/base/Dockerfile.ubuntu20.04-3-scipy
@@ -13,6 +13,11 @@ ENV LD_PRELOAD=""
 # Load backend IEEE
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
 
+# Setting compilers and linkers to use verificarlo
+ENV CC "verificarlo-c --conservative"
+ENV CXX "verificarlo-c++ --conservative"
+ENV FC "verificarlo-f --conservative"
+
 RUN pip3 install joblib
 RUN cp /usr/local/bin/verificarlo-f /usr/bin/gfortran
 RUN cd /opt/build/ &&\
@@ -27,8 +32,12 @@ RUN cd /opt/build/ &&\
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/scipy-1.5.4-py3.8-linux-x86_64.egg/scipy/linalg/cython_blas.cpython-38-x86_64-linux-gnu.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+
+
 # Restore default behavior for verificarlo's CC
 ENV CC "verificarlo-c"
+# Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
 
 ENV LD_PRELOAD=${LD_PRELOAD_OLD}

--- a/docker/base/Dockerfile.ubuntu20.04-3-scipy
+++ b/docker/base/Dockerfile.ubuntu20.04-3-scipy
@@ -19,7 +19,7 @@ RUN cd /opt/build/ &&\
   git clone https://github.com/scipy/scipy.git &&\
   cd /opt/build/scipy &&\
   git checkout v1.5.4 &&\
-  CFLAGS="--conservative" FFLAGS="--conservative" NPY_NUM_BUILD_JOBS=4 \
+  OPT="--conservative" FOPT="--conservative" NPY_NUM_BUILD_JOBS=4 \
   python3 setup.py config --compiler=verificarlo --fcompiler=verificarlof build_clib \
   --compiler=verificarlo --fcompiler=verificarlof build_ext \
   --compiler=verificarlo --fcompiler=verificarlof build -j 4 install

--- a/docker/base/Dockerfile.ubuntu20.04-4-sklearn
+++ b/docker/base/Dockerfile.ubuntu20.04-4-sklearn
@@ -1,14 +1,5 @@
 ARG VERIFICARLO_VERSION=v0.5.0
-FROM verificarlo/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5-numpy-scipy
-
-RUN cat /proc/cpuinfo | grep flags | uniq
-RUN  cat /proc/cpuinfo | grep "model name"  | uniq
-
-
-# Unset LD_PRELOAD because it will open VFC_BACKENDS_FROM_FILE
-# and causes bug
-RUN LD_PRELOAD_OLD=${LD_PRELOAD}
-ENV LD_PRELOAD=""
+FROM yohanchatelain/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5-numpy-scipy
 
 # Load backend IEEE
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
@@ -36,7 +27,5 @@ RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/sklearn/svm/_libl
 ENV CC "verificarlo-c"
 # Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
-
-ENV LD_PRELOAD=${LD_PRELOAD_OLD}
 
 ENTRYPOINT [ "/bin/bash"]

--- a/docker/base/Dockerfile.ubuntu20.04-4-sklearn
+++ b/docker/base/Dockerfile.ubuntu20.04-4-sklearn
@@ -13,6 +13,11 @@ ENV LD_PRELOAD=""
 # Load backend IEEE
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
 
+# Setting compilers and linkers to use verificarlo
+ENV CC "verificarlo-c --conservative"
+ENV CXX "verificarlo-c++ --conservative"
+ENV FC "verificarlo-f --conservative"
+
 RUN cd /opt/build &&\
   git clone https://github.com/scikit-learn/scikit-learn.git &&\
   cd scikit-learn &&\
@@ -22,8 +27,14 @@ RUN cd /opt/build &&\
 # Remove temporary files
 RUN rm -rf /opt/build/*
 
+# Check that no AVX2/AVX512 instructions are emitted
+RUN if [[ $( objdump -d /usr/local/lib/python3.8/site-packages/sklearn/svm/_liblinear.cpython-38-x86_64-linux-gnu.so | grep "%ymm\|%zmm" | wc -l ) != 0 ]] ; then exit 1 ; fi
+
+
+
 # Restore default behavior for verificarlo's CC
 ENV CC "verificarlo-c"
+# Restore default MCA mode
 RUN echo "libinterflop_mca.so -m rr" > $VFC_BACKENDS_FROM_FILE
 
 ENV LD_PRELOAD=${LD_PRELOAD_OLD}

--- a/docker/resources/verificarlo.patch
+++ b/docker/resources/verificarlo.patch
@@ -8,7 +8,7 @@ index 14cd655..a9090b8 100644
          f" -c -Wno-varargs -I {mcalib_includes} "
 -    shell(f'{clang} -O3 -march=native {internal_options} {extra_args} {source} -o {output} ')
 +    conservative = '-march=x86-64' if args.conservative else '-march=native'
-+    shell(f'{clang} -O3 {conservative} {internal_options} {extra_args} {source} -o {output} ')
++    shell(f'{clang} -O3 {internal_options} {extra_args} {source} -o {output} {conservative} ')
  
  
  def linker_mode(sources, options, libraries, output, args):


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please fill in the following brief template to help the maintainers evaluate their contribution.

-->

## Description of contribution
<!--- A clear and concise description of what the PR does. -->

This PR fixes the issue with target specific instructions generated by `--march=native`.

## Implementation Details
<!--- Provide a detailed description of the change or addition you are proposing -->

It patches verificarlo to add a conservative mode and turn-off generation of target specific instructions.
