### PR TITLE
update license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/218554957.svg)](https://zenodo.org/badge/latestdoi/218554957)
 [![Build Fuzzy Environments](https://github.com/verificarlo/fuzzy/actions/workflows/build-fuzzy.yml/badge.svg?branch=master)](https://github.com/verificarlo/fuzzy/actions/workflows/build-fuzzy.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/verificarlo/fuzzy)](https://hub.docker.com/r/verificarlo/fuzzy)
-[![GPL Licensed](https://img.shields.io/badge/license-GPL-blue)](./LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://releases.llvm.org/13.0.0/LICENSE.TXT)
 
 *A fuzzy ecosystem for evaluating the effect of numerical error on computational tools.*
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please fill in the following brief template to help the maintainers evaluate their contribution.

-->

## Description of contribution
I updated the license badge according to the license file and name at the end of this readme

## Implementation Details
I used the apache badge, but change the link to redirect on the apache 2.0 with llvm exception

The other option would have been to remove the badge entirely.
