### PR TITLE
Fix docker images

### DIFF
--- a/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
+++ b/docker/base/Dockerfile.ubuntu20.04-0-lapack-libmath
@@ -20,6 +20,7 @@ RUN patch $(which verificarlo) /tmp/verificarlo.patch
 ENV CC "verificarlo-c"
 ENV CXX "verificarlo-c++"
 ENV FC "verificarlo-f"
+ENV LDSHARED "verificarlo-c"
 
 # Load backend IEEE
 RUN mkdir -p /opt/ && touch /opt/vfc-backends.txt

--- a/docker/base/Dockerfile.ubuntu20.04-1-python
+++ b/docker/base/Dockerfile.ubuntu20.04-1-python
@@ -12,7 +12,10 @@ RUN cd /opt/build/ && \
     wget https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz && \
     tar xvf Python-3.8.5.tgz && \
     cd Python-3.8.5 && \
-    CFLAGS="--conservative --exclude-file=/tmp/python-vfc-exclude.txt" ./configure --with-ensurepip=install &&\
+    LDFLAGS="--conservative --exclude-file=/tmp/python-vfc-exclude.txt" \
+    CFLAGS="--conservative --exclude-file=/tmp/python-vfc-exclude.txt" \
+    LDSHARED='verificarlo-c -shared' \
+    ./configure --with-ensurepip=install &&\
     make -j &&\
     make install &&\ 
     wget https://bootstrap.pypa.io/get-pip.py &&\

--- a/docker/base/Dockerfile.ubuntu20.04-2-numpy
+++ b/docker/base/Dockerfile.ubuntu20.04-2-numpy
@@ -10,15 +10,14 @@ COPY docker/resources/numpy-sanity-check.py /tmp/numpy-sanity-check.py
 
 # Build numpy from sources and link with the local BLAS and LAPACK
 RUN python3 -m pip install cython
-# Numpy links libraries with x86_64-linux-gnu-gcc
-
-RUN ln -sf $(which verificarlo) $(which x86_64-linux-gnu-gcc)
 
 RUN cd /opt/build/ &&\
     wget https://github.com/numpy/numpy/releases/download/v1.22.0/numpy-1.22.0.tar.gz &&\
     tar xvf numpy-1.22.0.tar.gz &&\
     cd numpy-1.22.0 &&\
-    CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" CFGLAGS="--conservative --exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument" \
+    CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" LDSHARED='verificarlo-c -shared' \
+    CFLAGS="--conservative --exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument" \
+    LDFLAGS="--conservative --exclude-file=/tmp/numpy-vfc-exclude.txt -Wunused-command-line-argument" \
     python3 setup.py build -j $(nproc) --disable-optimization install
 
 

--- a/docker/base/Dockerfile.ubuntu20.04-3-scipy
+++ b/docker/base/Dockerfile.ubuntu20.04-3-scipy
@@ -11,8 +11,6 @@ COPY docker/resources/numpy-sanity-check.py /tmp/scipy-sanity-check.py
 RUN pip3 install joblib pythran pybind11
 # Replace gfortran with verificarlo-f
 RUN cp /usr/local/bin/verificarlo-f /usr/bin/gfortran
-# Replace gcc with verificarlo-c
-RUN ln -sf $(which verificarlo-c) $(which x86_64-linux-gnu-gcc)
 
 # Remove debug flag which makes flag crash
 RUN sed -i "294s/.*/    llvm_options = llvm_options.replace(\"'-g'\",'') if \"'-g'\" in llvm_options else llvm_options/" $(which verificarlo)
@@ -21,7 +19,9 @@ RUN cd /opt/build/ &&\
   wget https://github.com/scipy/scipy/releases/download/v1.7.3/scipy-1.7.3.tar.gz &&\
   tar xvf scipy-1.7.3.tar.gz &&\
   cd scipy-1.7.3 &&\
-  CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" CFGLAGS="--conservative -Wunused-command-line-argument" \
+  CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" LDSHARED='verificarlo-c -shared' \
+  CFLAGS="--conservative -Wunused-command-line-argument" \
+  LDFLAGS="--conservative -Wunused-command-line-argument" \
   python3 setup.py build --disable-optimization -j $(nproc) install
 
 # Restore original verificarlo

--- a/docker/base/Dockerfile.ubuntu20.04-4-sklearn
+++ b/docker/base/Dockerfile.ubuntu20.04-4-sklearn
@@ -5,11 +5,14 @@ FROM verificarlo/fuzzy:${VERIFICARLO_VERSION}-lapack-python3.8.5-numpy-scipy
 RUN echo "libinterflop_ieee.so" > $VFC_BACKENDS_FROM_FILE
 
 RUN cd /opt/build &&\
-  git clone https://github.com/scikit-learn/scikit-learn.git &&\
-  cd scikit-learn &&\
-  git checkout 1.0.2 &&\
-  CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" CFGLAGS="--conservative -Wunused-command-line-argument"\
-  python3 setup.py build -j 4 install
+  wget https://github.com/scikit-learn/scikit-learn/archive/refs/tags/1.0.2.tar.gz &&\
+  tar xvf  1.0.2.tar.gz &&\
+  cd scikit-learn-1.0.2 &&\
+  CC="verificarlo-c" FC="verificarlo-f" CXX="verificarlo-c++" \
+  CFLAGS="--conservative -Wunused-command-line-argument" \
+  LDFLAGS="--conservative -Wunused-command-line-argument" \
+  LDSHARED="verificarlo-c -shared" \
+  python3 -m pip install --verbose  . 
 
 # Remove temporary files
 RUN rm -rf /opt/build/*


### PR DESCRIPTION
    - Scikit-learn image still compile with full optimization on.
      TODO> Find a way to turn it off as --disable-optimization is not
      taken into account.

<!--
Thanks for opening a PR! Please fill in the following brief template to help the maintainers evaluate their contribution.

-->

## Description of contribution
<!--- A clear and concise description of what the PR does. -->

Fix architecture-specific instructions emitted when compiling Python sources.
Scikit-learn compilation does not accept the `--disable-optimization` flag and so
this image still contains specific instructions. 

## Implementation Details
<!--- Provide a detailed description of the change or addition you are proposing -->
