### PR TITLE
Update DOI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fuzzy v2.5.1
 
-[![DOI](https://zenodo.org/badge/218554957.svg)](https://zenodo.org/badge/latestdoi/218554957)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20906259-blue)](https://zenodo.org/badge/latestdoi/218554957)
 [![Build Fuzzy Environments](https://github.com/verificarlo/fuzzy/actions/workflows/build-fuzzy.yml/badge.svg?branch=master)](https://github.com/verificarlo/fuzzy/actions/workflows/build-fuzzy.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/verificarlo/fuzzy)](https://hub.docker.com/r/verificarlo/fuzzy)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://releases.llvm.org/13.0.0/LICENSE.TXT)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please fill in the following brief template to help the maintainers evaluate their contribution.

-->

## Description of contribution
<!--- A clear and concise description of what the PR does. -->

This PR fixes the DOI badge inside the `README.md` file. 

It previously showed up like this:

<img width="61" height="29" alt="image" src="https://github.com/user-attachments/assets/0ee228ba-901c-4d54-9c41-384230229347" />

This is now fixed and shows the badge properly:

<img width="149" height="32" alt="image" src="https://github.com/user-attachments/assets/0ac4a3b4-63cd-4d2e-aaa8-10e23bef7b9c" />


## Implementation Details
<!--- Provide a detailed description of the change or addition you are proposing -->

This PR introduces a simple change to the badge image link changing it from

`https://zenodo.org/badge/218554957.svg` to `https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20906259-blue`.